### PR TITLE
Corregir error de despliegue en Vercel: "No Output Directory named public"

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -9,7 +9,7 @@
       "src": "frontend/package.json",
       "use": "@vercel/static-build",
       "config": {
-        "distDir": "build"
+        "distDir": "frontend/build"
       }
     }
   ],
@@ -20,11 +20,12 @@
     },
     {
       "src": "/(.*)",
-      "dest": "frontend/$1"
+      "dest": "frontend/build/$1"
     },
     {
       "src": "/",
-      "dest": "frontend/index.html"
+      "dest": "frontend/build/index.html"
     }
-  ]
+  ],
+  "outputDirectory": "frontend/build"
 }


### PR DESCRIPTION
## Descripción del problema

El despliegue en Vercel está fallando con el error:
```
Error: No Output Directory named "public" found after the Build completed.
```

## Solución

He modificado el archivo `vercel.json` para corregir la configuración de despliegue:

1. Añadí la propiedad `"outputDirectory": "frontend/build"` para especificar explícitamente dónde Vercel debe buscar los archivos estáticos
2. Actualicé las rutas para que apunten a `frontend/build` en lugar de solo `frontend`
3. Modifiqué la configuración de `distDir` en la sección de builds para que sea la ruta completa `frontend/build`

Estos cambios permitirán que Vercel encuentre correctamente los archivos compilados del frontend y solucionará el error de despliegue.

## Cómo probar

1. Acepta y combina este PR
2. Realiza un nuevo despliegue en Vercel
3. El despliegue debería completarse correctamente sin el error de directorio de salida